### PR TITLE
feat: interface{} to any

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
   GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/services/exchange/db/custom.types.go
+++ b/services/exchange/db/custom.types.go
@@ -20,7 +20,7 @@ func (Rsi) GormDataType() string {
 	return "JSONB"
 }
 
-func (r *Rsi) Scan(value interface{}) error {
+func (r *Rsi) Scan(value any) error {
 	return json.Unmarshal(value.([]byte), &r)
 }
 
@@ -39,7 +39,7 @@ func (Macd) GormDataType() string {
 	return "JSONB"
 }
 
-func (r *Macd) Scan(value interface{}) error {
+func (r *Macd) Scan(value any) error {
 	return json.Unmarshal(value.([]byte), &r)
 }
 

--- a/services/exchange/db/seed.go
+++ b/services/exchange/db/seed.go
@@ -16,7 +16,7 @@ type seedConfig struct {
 
 type seed struct {
 	Name string
-	Type interface{}
+	Type any
 	Fn   func() error
 }
 

--- a/services/exchange/internal/api.go
+++ b/services/exchange/internal/api.go
@@ -31,7 +31,7 @@ func RunAsyncApi(DB db.DB, exchange Binance, pubsub PubSub) {
 		DB.UpdateStrategy(request.Strategy)
 
 		log.Trace().Msg("Internal.Strategy.Update")
-		var payload interface{}
+		var payload any
 		pubsub.Publish(m.Reply, payload)
 	})
 
@@ -79,7 +79,7 @@ func RunAsyncApi(DB db.DB, exchange Binance, pubsub PubSub) {
 		DB.UpdateConfigTradingEnabled(request.Symbol, request.Enabled)
 
 		log.Trace().Str("symbol", request.Symbol).Bool("enabled", request.Enabled).Msg("Internal.Config.TradingEnabled")
-		var payload interface{}
+		var payload any
 		pubsub.Publish(m.Reply, payload)
 	})
 
@@ -90,7 +90,7 @@ func RunAsyncApi(DB db.DB, exchange Binance, pubsub PubSub) {
 		DB.UpdateConfigAllowedAmount(request.Symbol, request.Amount)
 
 		log.Trace().Str("symbol", request.Symbol).Float64("amount", request.Amount).Msg("Internal.Config.AllowedAmount")
-		var payload interface{}
+		var payload any
 		pubsub.Publish(m.Reply, payload)
 	})
 

--- a/services/exchange/internal/pubsub.go
+++ b/services/exchange/internal/pubsub.go
@@ -25,7 +25,7 @@ func NewPubSub(addr, user, password string) PubSub {
 	return PubSub{enc}
 }
 
-func (p *PubSub) Subscribe(event string, handler interface{}) *nats.Subscription {
+func (p *PubSub) Subscribe(event string, handler any) *nats.Subscription {
 	sub, err := p.conn.Subscribe(event, handler)
 
 	if err != nil {
@@ -35,7 +35,7 @@ func (p *PubSub) Subscribe(event string, handler interface{}) *nats.Subscription
 	return sub
 }
 
-func (p *PubSub) Publish(event string, payload interface{}) {
+func (p *PubSub) Publish(event string, payload any) {
 	err := p.conn.Publish(event, payload)
 
 	if err != nil {

--- a/services/exchange/utils/common.go
+++ b/services/exchange/utils/common.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func Unmarshal(data []byte, ptr interface{}) error {
+func Unmarshal(data []byte, ptr any) error {
 	err := json.Unmarshal(data, ptr)
 
 	if err != nil {

--- a/services/notification/internal/message.go
+++ b/services/notification/internal/message.go
@@ -158,7 +158,7 @@ func (t Telegram) FormatErrorMessage(p CriticalErrorEventPayload) string {
 func (t Telegram) FormatUpdateTradingMessage(symbol string, enable bool) string {
 	var message string
 
-	var payload interface{}
+	var payload any
 	req := UpdateTradingEnabledRequest{symbol, enable}
 	err := t.pubsub.Request(UpdateTradingEnabledEvent, req, &payload)
 

--- a/services/notification/internal/pubsub.go
+++ b/services/notification/internal/pubsub.go
@@ -27,7 +27,7 @@ func NewPubSub(addr, user, password string) PubSub {
 	return PubSub{enc}
 }
 
-func (p *PubSub) Subscribe(event string, handler interface{}) *nats.Subscription {
+func (p *PubSub) Subscribe(event string, handler any) *nats.Subscription {
 	sub, err := p.conn.Subscribe(event, handler)
 
 	if err != nil {
@@ -37,7 +37,7 @@ func (p *PubSub) Subscribe(event string, handler interface{}) *nats.Subscription
 	return sub
 }
 
-func (p *PubSub) Publish(event string, payload interface{}) {
+func (p *PubSub) Publish(event string, payload any) {
 	err := p.conn.Publish(event, payload)
 
 	if err != nil {
@@ -45,7 +45,7 @@ func (p *PubSub) Publish(event string, payload interface{}) {
 	}
 }
 
-func (p PubSub) Request(event string, payload interface{}, response interface{}) error {
+func (p PubSub) Request(event string, payload any, response any) error {
 	err := p.conn.Request(event, payload, response, 5*time.Second)
 
 	if err != nil {


### PR DESCRIPTION
**Changelog**

- Migrate `interface{}` to `any` for Go v1.18